### PR TITLE
No.6 Spring Profilesごとに定数を定義する

### DIFF
--- a/src/main/kotlin/cypher/helloworld/controller/HelloworldController.kt
+++ b/src/main/kotlin/cypher/helloworld/controller/HelloworldController.kt
@@ -1,6 +1,7 @@
 package cypher.helloworld.controller
 
 import cypher.helloworld.entity.Reply
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -12,8 +13,9 @@ import javax.validation.constraints.Size
 class HelloworldController {
     @GetMapping("/")
     fun helloworld(
+        @Value(value = "\${helloworld.text}") text: String,
         @RequestParam @Size(min = NAME_MINIMUM_LENGTH, max = NAME_MAXIMUM_LENGTH) name: String,
-    ): Reply = Reply(message = "Hello, $name")
+    ): Reply = Reply(message = "Hello, $text, $name")
 
     companion object {
         private const val NAME_MINIMUM_LENGTH = 3

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,13 @@ server:
   error:
     whitelabel:
       enabled: false
+
+helloworld:
+  text: my friend
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+helloworld:
+  text: my best friend

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,11 +11,11 @@ server:
       enabled: false
 
 helloworld:
-  text: my friend
+  text: my best friend
 ---
 spring:
   config:
     activate:
       on-profile: dev
 helloworld:
-  text: my best friend
+  text: my friend


### PR DESCRIPTION
### やったこと

#6 No.6 Spring Profilesごとに定数を定義する

> 1. APIのResponseを {"message":"Hello $text, $name"} に修正してください
> 2. textの値はapplication.ymlに定義してApplication内で利用してください
> 3. spring profilesがdevのときはtextの値を変えてください
>   spring profiles dev以外の場合の出力: {"message":"Hello my best friend, foo"}
>   spring profiles がdevの場合の出力: {"message":"Hello my friend, foo"}

### やらなかったこと

### エビデンス

- `default`

![image](https://user-images.githubusercontent.com/16466322/136219833-a45c09f5-5bf8-4913-bb4f-7af5efef9b51.png)
![image](https://user-images.githubusercontent.com/16466322/136297766-bc60452a-716d-4ae2-8c46-2f565bdb4c69.png)

- `prod` （`dev` 以外）

![image](https://user-images.githubusercontent.com/16466322/136219517-6c828d2c-b3bb-4cce-8b7a-5dc67f4d8be5.png)!![image](https://user-images.githubusercontent.com/16466322/136297795-db8f5795-649e-45b1-af65-c3a12b5f32a4.png)

- `dev`

![image](https://user-images.githubusercontent.com/16466322/136219718-e989c70e-3832-40c7-9889-71c9aef40f9f.png)
![image](https://user-images.githubusercontent.com/16466322/136297852-3bdf783f-cbe9-41d8-bc6d-263e7122ee9a.png)

### 特にレビューして欲しい点

### その他
参考にしたもの：https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.files.activation-properties